### PR TITLE
bump version in melpa

### DIFF
--- a/highlight.el
+++ b/highlight.el
@@ -1098,10 +1098,12 @@
 ;;; Code:
 
 (eval-when-compile (unless (fboundp 'dolist) (require 'cl))) ;; dolist
+(require 'facemenu) ;; facemenu-add-face, facemenu-add-new-face, facemenu-menu
 (require 'easymenu) ;; easy-menu-add-item
 (require 'frame-fns nil t) ;; (no error if not found): flash-ding
 (require 'menu-bar+ nil t) ;; (no error if not found): menu-bar-edit-region-menu
 (when (> emacs-major-version 21) (require 'font-lock+ nil t)) ;; (no error if not found)
+(require 'facemenu+ nil t) ;; (no error if not found)
 
 ;; Quiet the byte-compiler for Emacs 20
 (defvar facemenu-mouse-menu)            ; In `facemenu+.el'


### PR DESCRIPTION
@tarsius If you don't mind merging this? Too my understanding I'm  following a procedure in [melpa recipe for `highlight`](https://github.com/melpa/melpa/commit/38433e95f73ab20f27254a084d0b245c6e62d882#diff-21757a7c3e02b8241c791e0d0778483d00ebe99ccfcd81bf7755d9690bae55ff) upgrades.

Rationale:
In recent version of emacs (at least on emacs-28.0.50 as found in a [`silex/emacs`](https://github.com/Silex/docker-emacs) docker image, a one with `master` tag, build on 2021-06-04) the `facemenu` is not loaded by default. This is not the case when `latest` tag is used (based on 27.2 build on 2021-05-19). I.e.,

```shell
$ docker run --rm -it silex/emacs:latest emacs --batch --eval '(progn facemenu-menu (message "OK"))'
OK
$ docker run --rm -it silex/emacs:master emacs --batch --eval '(progn facemenu-menu (message "OK"))'
Debugger entered--Lisp error: (void-variable facemenu-menu)
  (progn facemenu-menu (message "OK"))
  eval((progn facemenu-menu (message "OK")) t)
  command-line-1(("--eval" "(progn facemenu-menu (message \"OK\"))"))
  command-line()
  normal-top-level()
``` 

I've found this when I run a suite of tests for my own emacs configuration. The latter is, however too long to be of use for narrowing the issue down. After some debug I managed to narrow it to the following snippet:
```
$ docker run --rm -it silex/emacs:master emacs --batch --eval '(progn
(require '"'"'package)
(add-to-list '"'"'package-archives '"'"'("melpa" . "https://melpa.org/packages/") t)
(package-initialize t)
(package-refresh-contents)
(package-install '"'"'highlight)
(require '"'"'highlight)
(message "OK"))'

Debugger entered--Lisp error: (void-variable facemenu-menu)
  byte-code([...edited..])
  require(highlight)
  (progn (require 'package) (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t) (package-initialize t) (package-refresh-contents) (package-install 'highlight) (require 'highlight) (message "OK"))
  eval((progn (require 'package) (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t) (package-initialize t) (package-refresh-contents) (package-install 'highlight) (require 'highlight) (message "OK")) t)
  command-line-1(("--eval" "(progn\n(require 'package)\n(add-to-list 'package-ar..."))
  command-line()
  normal-top-level()
```
Throwing in `(require 'facemenu)' before `(require 'highlight)` makes the issue to disappear. The issue is also not reproducing when the `lastest` tag is used. Looking at the diff between `master` and `melpa` branches, I guess it's been fixed on wiki, but not merged yet. 